### PR TITLE
[JA] Fix submittingToLedger translation

### DIFF
--- a/src/locale/translations/ja.json
+++ b/src/locale/translations/ja.json
@@ -981,7 +981,7 @@
     "somethingWentWrong": "問題が発生しました！",
     "resultCopiedToClipboard": "結果をクリップボードにコピーしました",
     "txIdCopiedToClipboard": "トランザクションIDがクリップボードにコピーされました",
-    "submittingToLedger": "%{network}レジャーへトランザクションを送信中",
+    "submittingToLedger": "%{network}へトランザクションを送信中",
     "sendingFrom": "から送信しています",
     "enterDescription": "説明を入力してください",
     "enterPublicMemo": "公開メモを入力してください（オプション）",


### PR DESCRIPTION
Due to a pre-release change, the Japanese text has been changed to like 
`Sending your transaction to the %{network} ledger`.

The image is from the testnet, but on the mainnet, it is labeled as "XRP Ledger Ledger".

<img src="https://github.com/XRPL-Labs/Xaman-App/assets/69445828/09e5cb38-edca-4ce6-ad39-675855ac8fa9" width="320">
